### PR TITLE
fix: remove logging of sensitive information

### DIFF
--- a/include/git_wrapper.hpp
+++ b/include/git_wrapper.hpp
@@ -497,7 +497,7 @@ namespace xtypes
             }
             else if (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT)
             {
-                std::cout << "Repository::acquire_credentials(): Athenticating with HTTPS\n";
+                std::cout << "Repository::acquire_credentials(): Authenticating with HTTPS\n";
                 const Repository *__this = static_cast<Repository *>(payload);
                 if (__this->m_username.empty())
                     throw std::runtime_error("Repository::acquire_credentials(): username is missing");

--- a/src/GitReference.cpp
+++ b/src/GitReference.cpp
@@ -149,7 +149,6 @@ nl::json xtypes::GitReference::checkout_repository(const std::string& local_dir,
       else
       {
         remote_url = this->convert_url_to_https(remote_url, username, password);
-        std::cout<<username<<" "<<password<<" "<<remote_url;
         // Otherwise, clone the git from remote
         try
         {


### PR DESCRIPTION
When a SSH git URL was converted to a HTTPS git URL, a log message containing the username and password/ access token was logged. This seems to be a debugging leftover and should be removed.